### PR TITLE
HR Module Updates

### DIFF
--- a/app/Controllers/HR/Employee.php
+++ b/app/Controllers/HR/Employee.php
@@ -233,7 +233,8 @@ class Employee extends BaseController
                     $data['message']    = res_lang('error.validation');
                 } else {
                     // Delete also their accounts
-                    $this->_model->deleteEmployeeAccounts($record['employee_id']);
+                    $accountModel   = new AccountModel();
+                    $accountModel->removeUsingEmployeeId($record['employee_id']);
                 }
 
                 return $data;
@@ -297,8 +298,9 @@ class Employee extends BaseController
                 } else {
                     // If resigned, delete their accounts
                     if ($resigned) {
-                        $employee_id = $this->request->getVar('employee_id');
-                        $this->_model->deleteEmployeeAccounts($employee_id);
+                        $employee_id    = $this->request->getVar('employee_id');
+                        $accountModel   = new AccountModel();
+                        $accountModel->removeUsingEmployeeId($employee_id);
                     }
                 }
 

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -14,7 +14,7 @@ class AccountModel extends Model
     protected $useAutoIncrement = true;
     protected $insertID         = 0;
     protected $returnType       = 'array';
-    protected $useSoftDeletes   = false;
+    protected $useSoftDeletes   = true;
     protected $protectFields    = true;
     protected $allowedFields    = [
         'employee_id',
@@ -78,11 +78,14 @@ class AccountModel extends Model
     // Check user trying to delete own account
     protected function checkRecordIfOneself($data) 
     {
-        $id     = $data['id'];
-        $result = $this->getAccounts($id);
+        $id = $data['id'][0];
 
-        if ($result[0]['username'] === session('username'))  {
-            throw new \Exception("You can't delete your own record!", 2);
+        if (is_numeric($id)) {
+            $result = $this->getAccounts($id);
+    
+            if (! empty($result) && $result[0]['username'] === session('username'))  {
+                throw new \Exception("You can't delete your own record!", 2);
+            }
         }
     }
 
@@ -130,6 +133,15 @@ class AccountModel extends Model
         $builder->where('username', $username);
 
         return ! empty($builder->first());
+    }
+
+    // Remove account using employee_id - not the primary id
+    public function removeUsingEmployeeId($employee_id) 
+    {
+        $this->primaryKey = 'employee_id';
+        $this->where('employee_id', $employee_id);
+
+        return $this->delete($employee_id);
     }
 
     // For dataTables

--- a/app/Models/EmployeeModel.php
+++ b/app/Models/EmployeeModel.php
@@ -326,28 +326,6 @@ class EmployeeModel extends Model
         return $this;
     }
 
-    // If employee record is deleted or marked as resigned
-    // delete their corresponding account(s)
-    public function deleteEmployeeAccounts($employee_id)
-    {
-        if ($employee_id) {
-            // If the pass param is numberic or 
-            // the primary id, the get the employee_id
-            if (is_numeric($employee_id)) {
-                $record         = $this->getEmployees($employee_id, null, 'employee_id');
-                $employee_id    = $record['employee_id'];
-            }
-
-            // Delete corresponding accounts - if exist
-            // Used query builder since can't delete using model (encountered error)
-            // Totally delete it in db
-            $accountModel = new AccountModel();
-            $this->db->table($accountModel->table)
-                ->where('employee_id', $employee_id)
-                ->delete();
-        }
-    }
-
     // Get employees
     public function getEmployees($id = null, $employee_id = null, $columns = null, $without_resign = false) 
     {


### PR DESCRIPTION
Now, the deletion or changing the employee record to resigned were using th soft deleted instead of the complete delete prior. This was to prevent error in getting the account name for the created_by field.